### PR TITLE
fixed ajax call url for ssl

### DIFF
--- a/code/GoogleSuggestField.php
+++ b/code/GoogleSuggestField.php
@@ -19,7 +19,7 @@ class GoogleSuggestField extends FormField {
 							$( "#Form_EditForm_{$this->getName()}" ).autocomplete({
 								source: function( request, response ) {
 									$.ajax({
-									  url: "http://suggestqueries.google.com/complete/search",
+									  url: "//suggestqueries.google.com/complete/search",
 									  dataType: "jsonp",
 									  data: {
 										  client: 'firefox',


### PR DESCRIPTION
Changed url FROM http://suggestqueries.google.com/complete/search TO  //suggestqueries.google.com/complete/search because it didnt work over https and broke admin ajax interface. 
Not specifying protocol making it compatible with both http and https sites and solves the issue given many websites use https for CMS. 
Cheers