### PR TITLE
Fix Requirements statements for seo css and js files

### DIFF
--- a/src/SeoObjectExtension.php
+++ b/src/SeoObjectExtension.php
@@ -114,7 +114,7 @@ class SeoObjectExtension extends DataExtension
         }
 
         Requirements::css('hubertusanton/silverstripe-seo:client/css/seo.css');
-        Requirements::javascript('hubertusanton/silverstripe-seo:client/javascript/seo.js');
+        Requirements::javascript('hubertusanton/silverstripe-seo:client/js/seo.js');
 
         // better do this below in some init method? :
         $this->getSEOScoreCalculation();

--- a/src/SeoObjectExtension.php
+++ b/src/SeoObjectExtension.php
@@ -113,8 +113,8 @@ class SeoObjectExtension extends DataExtension
             }
         }
 
-        Requirements::css('hubertusanton/silverstripe-seo:css/seo.css');
-        Requirements::javascript('hubertusanton/silverstripe-seo:javascript/seo.js');
+        Requirements::css('hubertusanton/silverstripe-seo:client/css/seo.css');
+        Requirements::javascript('hubertusanton/silverstripe-seo:client/javascript/seo.js');
 
         // better do this below in some init method? :
         $this->getSEOScoreCalculation();


### PR DESCRIPTION
seo.css and seo.js showing as 404 in admin area due to missing 'client' path in Requirement statements.