### PR TITLE
Change seo.js field references to work with GridFieldDetailForm

### DIFF
--- a/client/js/seo.js
+++ b/client/js/seo.js
@@ -1,8 +1,5 @@
-
 (function($) {
-
 		$.entwine('ss', function($){
-
 			$('.cms-edit-form textarea[name=MetaDescription]').entwine({
 				// Constructor: onmatch
 				onkeyup : function() {
@@ -18,11 +15,9 @@
 
 			var page_url_basehref = $('input[name="URLSegment"]').attr('data-prefix'),
 				page_url_segment = $('input[name="URLSegment"]').val(),
-				page_title       = $('#Form_EditForm_Title').val(),
-				page_menutitle  = $('#Form_EditForm_MenuTitle').val(),
-				page_content     = $('textarea#Form_EditForm_Content').val(),
-				page_metadata_title = $('#Form_EditForm_MetaTitle').val(),
-				page_metadata_description = $('#Form_EditForm_MetaDescription').val(),
+				page_title       = $('input[name="Title"').val(),
+				page_metadata_title = $('input[name="MetaTitle"]').val(),
+				page_metadata_description = $('textarea[name="MetaDescription"]').val(),
 				siteconfig_title = $('#ss_siteconfig_title').html();
 
 				// build google search preview
@@ -43,9 +38,3 @@
 		}
 	
 })(jQuery);
-
-
-
-
-
-

--- a/src/GoogleSuggestField.php
+++ b/src/GoogleSuggestField.php
@@ -15,11 +15,11 @@ class GoogleSuggestField extends FormField {
 
                 $.entwine('ss', function($){
 
-                    $('.cms-edit-form input#Form_EditForm_{$this->getName()}').entwine({
+                    $('.cms-edit-form input[name="{$this->getName()}"]').entwine({
                         // Constructor: onmatch
                         onmatch : function() {
 
-                            $( "#Form_EditForm_{$this->getName()}" ).autocomplete({
+                            $('input[name="{$this->getName()}"]').autocomplete({
                                 source: function( request, response ) {
                                     $.ajax({
                                       url: "//suggestqueries.google.com/complete/search",


### PR DESCRIPTION
At the moment, any object extended with `SeoObjectExtension` and edited via a `GridFieldDetailForm` fails to utilise seo.js (meaning the autocomplete field and google preview fail to work).

It appears seo.js is referencing CMS specific fields, using the field's ID (which can change, depending on the form).

This PR changes these references to use the field's `name` instead (which should then work in any form).