### PR TITLE
Add ability to add Facebook OG and Twitter tags to MetaTags

### DIFF
--- a/lang/de.yml
+++ b/lang/de.yml
@@ -26,3 +26,8 @@ de:
     SEOSubjectCheckPageContent: 'Seiteninhalt:'
     SEOSubjectCheckPageURL: 'Seiten-URL:'
     SEOSubjectCheckPageMetaDescription: 'Seitenbeschreibung (description):'
+    SEOSocialData: 'Soziale Daten'
+    SEOHideSocialDataDescription: 'Soziale Daten vor HTML-Seiten verbergen?'
+    SEOSocialType: 'Typ des sozialen Inhalts'
+    SEOSocialImage: 'Bild zum Teilen in sozialen Medien'
+    SEODefaultImage: 'Standardmäßig wird das Bild angezeigt, sofern verfügbar'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -30,3 +30,8 @@ en:
     SEOGoogleWebmasterMetaTag: 'Google webmaster meta tag'
     SEOGoogleWebmasterMetaTagRightTitle: 'Full Google webmaster meta tag For example &lt;meta name="google-site-verification" content="hjhjhJHG12736JHGdfsdf" &gt;'
     SEOScoreTipImagesHaveTitleTags: 'All images on this page do not have title tags'
+    SEOSocialData: 'Social Data'
+    SEOHideSocialDataDescription: 'Hide Social Data From Pages HTML?'
+    SEOSocialType: 'Social Content Type'
+    SEOSocialImage: 'Image to share on Social Media'
+    SEODefaultImage: 'Defaults to featured image, if available'

--- a/lang/es.yml
+++ b/lang/es.yml
@@ -26,3 +26,8 @@ es:
     SEOSubjectCheckPageContent: 'Contenido de la página:'
     SEOSubjectCheckPageURL: 'URL de la página:'
     SEOSubjectCheckPageMetaDescription: 'Descripción META de la página:'
+    SEOSocialData: 'Datos sociales'
+    SEOHideSocialDataDescription: '¿Ocultar datos sociales de páginas HTML?'
+    SEOSocialType: 'Tipo de contenido social'
+    SEOSocialImage: 'Imagen para compartir en las redes sociales'
+    SEODefaultImage: 'El valor predeterminado es la imagen destacada, si está disponible.'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -31,7 +31,7 @@ nl:
     SEOGoogleWebmasterMetaTagRightTitle: 'Full Google webmaster meta tag. Bijvoorbeeld &lt;meta name="google-site-verification" content="hjhjhJHG12736JHGdfsdf" &gt;'
     SEOScoreTipImagesHaveTitleTags: 'Alle afbeeldingen op deze pagina hebben geen title tags'
     SEOSocialData: 'Sociale gegevens'
-    SEOHideSocialDataDescription: 'Sociale gegevens verbergen van pagina's HTML?'
+    SEOHideSocialDataDescription: 'Sociale gegevens verbergen van in HTML?'
     SEOSocialType: 'Type sociale inhoud'
     SEOSocialImage: 'Afbeelding om te delen op sociale media'
     SEODefaultImage: 'Wordt standaard weergegeven op de afbeelding, indien beschikbaar'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -30,3 +30,8 @@ nl:
     SEOGoogleWebmasterMetaTag: 'Google webmaster meta tag'
     SEOGoogleWebmasterMetaTagRightTitle: 'Full Google webmaster meta tag. Bijvoorbeeld &lt;meta name="google-site-verification" content="hjhjhJHG12736JHGdfsdf" &gt;'
     SEOScoreTipImagesHaveTitleTags: 'Alle afbeeldingen op deze pagina hebben geen title tags'
+    SEOSocialData: 'Sociale gegevens'
+    SEOHideSocialDataDescription: 'Sociale gegevens verbergen van pagina's HTML?'
+    SEOSocialType: 'Type sociale inhoud'
+    SEOSocialImage: 'Afbeelding om te delen op sociale media'
+    SEODefaultImage: 'Wordt standaard weergegeven op de afbeelding, indien beschikbaar'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -31,7 +31,7 @@ nl:
     SEOGoogleWebmasterMetaTagRightTitle: 'Full Google webmaster meta tag. Bijvoorbeeld &lt;meta name="google-site-verification" content="hjhjhJHG12736JHGdfsdf" &gt;'
     SEOScoreTipImagesHaveTitleTags: 'Alle afbeeldingen op deze pagina hebben geen title tags'
     SEOSocialData: 'Sociale gegevens'
-    SEOHideSocialDataDescription: 'Sociale gegevens verbergen van in HTML?'
+    SEOHideSocialDataDescription: 'Sociale gegevens verbergen in HTML?'
     SEOSocialType: 'Type sociale inhoud'
     SEOSocialImage: 'Afbeelding om te delen op sociale media'
     SEODefaultImage: 'Wordt standaard weergegeven op de afbeelding, indien beschikbaar'

--- a/templates/Hubertusanton/SilverStripeSeo/Includes/SocialTags.ss
+++ b/templates/Hubertusanton/SilverStripeSeo/Includes/SocialTags.ss
@@ -1,0 +1,20 @@
+<% if not $SEOHideSocialData %>
+    <meta property="og:site_name" content="$SiteConfig.Title" />
+    <meta property="og:locale" content="$i18nLocale" />
+
+    <meta property="og:title" content="$SEOSocialTitle" />
+    <meta name="twitter:title" content="$SEOSocialTitle" />
+
+    <% if $MetaDescription %>
+        <meta property="og:description" content="$MetaDescription" />
+        <meta name="twitter:description" content="$MetaDescription" />
+    <% end_if %>
+
+    <meta property="og:type" content="$SEOSocialType" />
+    <meta property="og:url" content="$AbsoluteLink" />
+
+    <% if $SEOPreferedSocialImage.exists %>
+        <meta property="og:image" content="$SEOPreferedSocialImage.AbsoluteLink" />
+        <meta name="twitter:image" content="$SEOPreferedSocialImage.AbsoluteLink" />
+    <% end_if %>
+<% end_if %>


### PR DESCRIPTION
I have tried to keep this fairly simple, and I have tried to focus on what I would call the "main" tags, rather than trying to find a way to add all the different tags.

I also tried to add a little bit of intelligence, so the `Title` looks to see if `MetaTitle` is available (say via https://github.com/kinglozzer/silverstripe-metatitle) and the image looks for `FeaturedImage` (for example, if you are viewing a blog post) if Social Image is not set.