### PR TITLE
Remove new social fields before re-adding

### DIFF
--- a/src/SeoObjectExtension.php
+++ b/src/SeoObjectExtension.php
@@ -167,8 +167,15 @@ class SeoObjectExtension extends DataExtension
         );
 
         // move Metadata field from Root.Main to SEO tab for visualising direct impact on search result
-
-        $fields->removeFieldFromTab('Root.Main', 'Metadata');
+        $fields->removeFieldsFromTab(
+            'Root.Main',
+            [
+                'Metadata',
+                'SEOSocialType',
+                'SEOHideSocialData',
+                'SEOSocialImage'
+            ]
+        );
 
         $fields->addFieldsToTab(
             'Root.SEO',


### PR DESCRIPTION
I installed this module on a slightly more complex module today and the CMS scaffolding failed to automatically move the new fields. Instead it added them twice (which caused an error).

As I am manually re-adding the fields anyway, it is probably nest to not rely on CMS Fields sorting themselves out (as I imagine issues like this could happen quite a lot)? 