### PR TITLE
Fix deprecation by making sure preg_match gets empty string if MetaTtle or Title is null

### DIFF
--- a/src/SeoObjectExtension.php
+++ b/src/SeoObjectExtension.php
@@ -585,9 +585,9 @@ class SeoObjectExtension extends DataExtension
      */
     public function checkPageSubjectInTitle() {
         if ($this->checkPageSubjectDefined()) {
-            if (preg_match('/' . preg_quote($this->owner->SEOPageSubject, '/') . '/i', $this->owner->MetaTitle)) {
+            if (preg_match('/' . preg_quote($this->owner->SEOPageSubject, '/') . '/i', $this->owner->MetaTitle ?? '')) {
                 return true;
-            } elseif (preg_match('/' . preg_quote($this->owner->SEOPageSubject, '/') . '/i', $this->owner->Title)) {
+            } elseif (preg_match('/' . preg_quote($this->owner->SEOPageSubject, '/') . '/i', $this->owner->Title ?? '')) {
                 return true;
             } else {
                 return false;
@@ -812,7 +812,7 @@ class SeoObjectExtension extends DataExtension
     public function getPageContent()
     {
         static $cache = null;
-        
+
         if ($cache === null) {
             $session = [];
             if (Controller::has_curr()) {
@@ -826,7 +826,7 @@ class SeoObjectExtension extends DataExtension
                 $cache = '';
             }
         }
-        
+
         return $cache;
     }
 }


### PR DESCRIPTION
After upgrading to SS5 I've got the following deprecation note;
```
\[Deprecated\] preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated GET /admin/pages/edit/show/7 Line 588 in /app/vendor/hubertusanton/silverstripe-seo/src/SeoObjectExtension.php[Deprecated] preg_match(): Passing null to parameter [#2 (closed)](https://github.com/robert-silverstripe/autopoetstwello/-/issues/2) ($subject) of type string is deprecated
GET /admin/pages/edit/show/7
Line 588 in /app/vendor/hubertusanton/silverstripe-seo/src/SeoObjectExtension.php
```

Decided to add empty strings at 2 lines if the value is null. This fixes the deprecation.

Ps. If this gets merged, would appreciate some SS5 tag/release for this repo :smile: 